### PR TITLE
fix: for iOS, mark tzeit as a time

### DIFF
--- a/hebrew.py
+++ b/hebrew.py
@@ -51,7 +51,9 @@ def textforday(kwargs):
                45: 'ראש חודש סיון'}
 
     try:
-        tzeit = 'צאת הכוכבים׃' + kwargs['nightfall'].strftime(u'%H:%M %Y-%m-%d')
+        nightfall = kwargs['nightfall'].strftime('%Y-%m-%d %H:%M')
+        tzeit = 'צאת הכוכבים׃ <time datetime="{0}" dir="ltr">{0}</time>'.format(nightfall)
+
         twilight = 'background-color:#ddd;' if kwargs['now'] < kwargs['nightfall'] and kwargs['now'] > kwargs['sunset'] and not kwargs['print'] else ''
         bracha_style = 'color:#aaa;font-size:14px;' if kwargs['now'] < kwargs['sunset'] and kwargs['now'] > kwargs['dawn'] and not kwargs['print'] else 'font-size:21px;'
     except KeyError:

--- a/templates/main.html
+++ b/templates/main.html
@@ -98,7 +98,12 @@
     <table>
       <tr>
         <td>
-          {{ tzeit }} - <span style="text-decoration: underline;" onClick=getLocation() tabindex=0>{{ zipcode }}</span> {{ special }}
+          {{ tzeit | safe }}
+          -
+          <span style="text-decoration: underline;" onClick=getLocation() tabindex=0>
+            {{ zipcode }}
+          </span>
+          {{ special }}
           <hr>
         </td>
       </tr>


### PR DESCRIPTION
Otherwise, WebKit will detect it as a phone number and turn it into a tel: link. Confirmed under iOS 15.5 and 16.4.

Before (see the first line, where tzeit is displayed):
<img width="600" alt="before" src="https://user-images.githubusercontent.com/7785285/232404132-b5901d8d-b9e1-4b41-a8c2-8514cf823254.png">

After:
<img width="600" alt="after" src="https://user-images.githubusercontent.com/7785285/232404147-5cb3696f-1a29-4a74-a463-6bf22caa4f2d.png">
